### PR TITLE
bikeshedding

### DIFF
--- a/theme/login/login.ftl
+++ b/theme/login/login.ftl
@@ -23,9 +23,6 @@
             <img class="logo" src="${url.resourcesPath}/img/ocf-logo.svg" alt="OCF">
         </div>
         <div class="box-container">
-            <div>
-                <p class="application-name">OCF Authentication</p>
-            </div>
         <#if realm.password>
             <div>
                <form id="kc-form-login" class="form" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">


### PR DESCRIPTION
Some people think ~~the bikeshed should be blue~~ the text should be removed, others think ~~the bikeshed should be yellow~~ the text is important so that you know you're supposed to sign in, and yet others think that ~~the bikeshed should be green~~ it's ok to remove the text, as long as the placeholder text makes it clear that you should use your _OCF_ credentials as opposed to... idk... bank account credentials? ~~For me, they're the same thing.~~

Unfortunately, I'm the one making the PR, so we're going with option number 1.

